### PR TITLE
Fix creation of new child frames

### DIFF
--- a/src/frameobject.ts
+++ b/src/frameobject.ts
@@ -116,10 +116,17 @@ class Py_FrameObject {
 
     // clone a new frame off this one, for calling a child function.
     childFrame(func: Py_FuncObject, locals: { [name: string]: IPy_Object }): Py_FrameObject {
-        return new Py_FrameObject(this, func.code,
-            func.globals, -1, func.code.firstlineno, locals, false,
+      if(!this.back){
+          return new Py_FrameObject(this, func.code,
+            this.locals, -1, func.code.firstlineno, locals, false,
             this.outputDevice);
+    
+      }
+      else {
+        return new Py_FrameObject(this, func.code,
+          this.globals, -1, func.code.firstlineno, locals, false,
+          this.outputDevice);
+      }
     }
-
 }
 export = Py_FrameObject;

--- a/src/optable.ts
+++ b/src/optable.ts
@@ -752,9 +752,7 @@ optable[opcodes.CALL_FUNCTION] = function(f: Py_FrameObject) {
                 }
             }
         }
-        // Add function itself to its globals
-        if (f.locals[(<Py_FuncObject> func).name.toString()] != undefined)
-            f.globals[(<Py_FuncObject> func).name.toString()] = f.locals[(<Py_FuncObject> func).name.toString()];
+
         var newf = f.childFrame((<Py_FuncObject> func), kwargs);
         newf.exec();
     } else {


### PR DESCRIPTION
As https://github.com/plasma-umass/Ninia/pull/11 pointed out, there was an issue with recursion calls. The issue, I think, is not with the implementation of `CALL_FUNCTION`, but with the creation of child frames. When a new child frame is created off the global frame, the locals of the global frame should be passed in as the globals of the child frame.