### PR TITLE
Use Py_Cell for closures

### DIFF
--- a/pytests/functions/scopeTest.py
+++ b/pytests/functions/scopeTest.py
@@ -12,3 +12,12 @@ def outer(arg=5):
 
 outer()
 
+def o():
+  a = 0
+  def i():
+    return a
+  a += 1
+  return i
+
+i = o()
+print i()

--- a/src/cell.ts
+++ b/src/cell.ts
@@ -1,0 +1,20 @@
+import interfaces = require('./interfaces');
+import IPy_Object = interfaces.IPy_Object;
+import enums = require('./enums');
+
+class Py_Cell implements IPy_Object {
+    ob_ref: IPy_Object;
+    
+    public constructor(ob_ref: IPy_Object){
+        this.ob_ref = ob_ref;
+    }
+    
+    public getType(): enums.Py_Type { return enums.Py_Type.OTHER; }
+    
+    public hash(): number {
+        return -1;
+    }
+
+}
+
+export = Py_Cell;

--- a/src/frameobject.ts
+++ b/src/frameobject.ts
@@ -4,6 +4,7 @@ import Py_CodeObject = require('./codeobject');
 import Py_FuncObject = require('./funcobject');
 import opcodes = require('./opcodes');
 import optable = require('./optable');
+import Py_Cell = require('./cell');
 
 // Frame Objects are basically stack frames for functions, except they carry
 // extra context (e.g. globals, local scope, etc.). This class is not simplified
@@ -44,7 +45,8 @@ class Py_FrameObject {
     // TODO: type this correctly
     blockStack: [number, number, number][];
     // Lexical environment
-    env: IPy_Object[];
+    // cellvars followed by freevars
+    env: Py_Cell[];
 
     constructor(back: Py_FrameObject,
                 code: Py_CodeObject,
@@ -54,7 +56,7 @@ class Py_FrameObject {
                 locals: { [name: string]: IPy_Object },
                 restricted: boolean,
                 outputDevice: any,
-                env: IPy_Object[]) {
+                closure: IPy_Object[]) {
         this.back = back;
         this.codeObj = code;
         this.globals = globals;
@@ -66,7 +68,16 @@ class Py_FrameObject {
         this.outputDevice = outputDevice;
         this.shouldWriteSpace = false;
         this.blockStack = [];
-        this.env = env;
+        this.env = [];
+        
+        for (var i = 0; i < code.cellvars.length; i++) {
+            this.env.push(new Py_Cell(null));
+        }
+
+        for (var i = 0; i < code.freevars.length; i++) {
+            this.env.push(<Py_Cell>closure[i]);
+        }
+
     }
 
     // Stack handling operations.

--- a/src/frameobject.ts
+++ b/src/frameobject.ts
@@ -136,5 +136,21 @@ class Py_FrameObject {
       return new Py_FrameObject(this, func.code, scope, -1,
         func.code.firstlineno, locals, false, this.outputDevice, env);
     }
+
+    getDeref(i: number) {
+        var cell: Py_Cell = this.env[i];
+        if (cell.ob_ref === null) {
+            var name: string;
+            var numCellvars = this.codeObj.cellvars.length;
+            if (i < numCellvars) {
+                name = this.codeObj.cellvars[i].toString();
+
+            } else {
+                name = this.codeObj.freevars[i - numCellvars].toString();
+            }
+            cell.ob_ref = this.locals[name];
+        }
+        return cell;
+    }
 }
 export = Py_FrameObject;

--- a/src/frameobject.ts
+++ b/src/frameobject.ts
@@ -69,12 +69,12 @@ class Py_FrameObject {
         this.shouldWriteSpace = false;
         this.blockStack = [];
         this.env = [];
-        
-        for (var i = 0; i < code.cellvars.length; i++) {
+        var i: number;
+        for (i = 0; i < code.cellvars.length; i++) {
             this.env.push(new Py_Cell(null));
         }
 
-        for (var i = 0; i < code.freevars.length; i++) {
+        for (i = 0; i < code.freevars.length; i++) {
             this.env.push(<Py_Cell>closure[i]);
         }
 

--- a/src/optable.ts
+++ b/src/optable.ts
@@ -521,21 +521,7 @@ optable[opcodes.LOAD_GLOBAL] = function(f: Py_FrameObject) {
 
 optable[opcodes.LOAD_DEREF] = function(f: Py_FrameObject) {
     var i = f.readArg();
-    var cell = <Py_Cell> f.env[i];
-    
-    if (cell.ob_ref === null) {
-        var name;
-        var numCellvars = f.codeObj.cellvars.length;
-        if (i < numCellvars) {
-            name = f.codeObj.cellvars[i].toString();
-
-        } else {
-            name = f.codeObj.freevars[i - numCellvars].toString();
-        }
-        cell.ob_ref = f.locals[name];
-    }
-    f.push(cell.ob_ref);
-
+    f.push(f.getDeref(i).ob_ref);
 }
 
 optable[opcodes.STORE_DEREF] = function(f: Py_FrameObject) {
@@ -546,20 +532,7 @@ optable[opcodes.STORE_DEREF] = function(f: Py_FrameObject) {
 
 optable[opcodes.LOAD_CLOSURE] = function(f: Py_FrameObject) {
     var i = f.readArg();
-    // Pushes a reference to the cell contained in slot i of the cell and free variable storage
-    var cell = <Py_Cell> f.env[i];
-    if (cell.ob_ref === null) {
-        var name;
-        var numCellvars = f.codeObj.cellvars.length;
-        if (i < numCellvars) {
-            name = f.codeObj.cellvars[i].toString();
-
-        } else {
-            name = f.codeObj.freevars[i - numCellvars].toString();
-        }
-        cell.ob_ref = f.locals[name];
-    }
-    f.push(cell);
+    f.push(f.getDeref(i));
 }
 
 optable[opcodes.COMPARE_OP] = function(f: Py_FrameObject) {


### PR DESCRIPTION
Use `Py_Cell` for storing indirect references to objects. A level of indirection is required so that changes that occur to the variable are reflected in the closure.